### PR TITLE
Name updates

### DIFF
--- a/data/102/312/305/102312305.geojson
+++ b/data/102/312/305/102312305.geojson
@@ -175,6 +175,12 @@
     "name:ell_x_preferred":[
         "\u039f\u03c1\u03b3\u03b1\u03bd\u03b9\u03c3\u03bc\u03cc\u03c2 \u0397\u03bd\u03c9\u03bc\u03ad\u03bd\u03c9\u03bd \u0395\u03b8\u03bd\u03ce\u03bd"
     ],
+    "name:eng_ca_x_preferred":[
+        "United Nations"
+    ],
+    "name:eng_gb_x_preferred":[
+        "United Nations"
+    ],
     "name:eng_x_preferred":[
         "United Nations"
     ],
@@ -437,6 +443,9 @@
     "name:mlt_x_preferred":[
         "\u0120nus Mag\u0127quda"
     ],
+    "name:mnw_x_preferred":[
+        "\u1000\u102f\u101c\u101e\u1019\u1002\u1039\u1002"
+    ],
     "name:mon_x_preferred":[
         "\u041d\u044d\u0433\u0434\u0441\u044d\u043d \u04ae\u043d\u0434\u044d\u0441\u0442\u043d\u0438\u0439 \u0411\u0430\u0439\u0433\u0443\u0443\u043b\u043b\u0430\u0433\u0430"
     ],
@@ -488,6 +497,9 @@
     "name:nov_x_preferred":[
         "Unionati Nationes"
     ],
+    "name:nqo_x_preferred":[
+        "\u07e1\u07ca\u07f2\u07ec\u07d5\u07cf\u07f2\u07eb \u07d8\u07cd\u07ec\u07e3\u07cd\u07f2"
+    ],
     "name:nrm_x_preferred":[
         "Organisatioun des Natiouns Eunies"
     ],
@@ -523,6 +535,9 @@
     ],
     "name:pol_x_preferred":[
         "Organizacja Narod\u00f3w Zjednoczonych"
+    ],
+    "name:por_br_x_preferred":[
+        "Organiza\u00e7\u00e3o das Na\u00e7\u00f5es Unidas"
     ],
     "name:por_x_preferred":[
         "Organiza\u00e7\u00e3o das Na\u00e7\u00f5es Unidas"
@@ -619,6 +634,12 @@
     ],
     "name:srd_x_preferred":[
         "ONU"
+    ],
+    "name:srp_ec_x_preferred":[
+        "\u041e\u0440\u0433\u0430\u043d\u0438\u0437\u0430\u0446\u0438\u0458\u0430 \u0443\u0458\u0435\u0434\u0438\u045a\u0435\u043d\u0438\u0445 \u043d\u0430\u0446\u0438\u0458\u0430"
+    ],
+    "name:srp_el_x_preferred":[
+        "Organizacija ujedinjenih nacija"
     ],
     "name:srp_x_preferred":[
         "\u041e\u0440\u0433\u0430\u043d\u0438\u0437\u0430\u0446\u0438\u0458\u0430 \u0443\u0458\u0435\u0434\u0438\u045a\u0435\u043d\u0438\u0445 \u043d\u0430\u0446\u0438\u0458\u0430"
@@ -740,8 +761,26 @@
     "name:zha_x_preferred":[
         "Lenzhozgoz"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u8054\u5408\u56fd"
+    ],
+    "name:zho_hk_x_preferred":[
+        "\u806f\u5408\u570b"
+    ],
     "name:zho_min_nan_x_preferred":[
         "Li\u00e2n-ha\u030dp-kok"
+    ],
+    "name:zho_mo_x_preferred":[
+        "\u806f\u5408\u570b"
+    ],
+    "name:zho_my_x_preferred":[
+        "\u8054\u5408\u56fd"
+    ],
+    "name:zho_sg_x_preferred":[
+        "\u8054\u5408\u56fd"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u806f\u5408\u570b"
     ],
     "name:zho_x_preferred":[
         "\u8054\u5408\u56fd"
@@ -793,7 +832,7 @@
         "spa",
         "mul"
     ],
-    "wof:lastmodified":1566595815,
+    "wof:lastmodified":1587428383,
     "wof:name":"United Nations",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.