### PR TITLE
un concordances, placetype local, and more

### DIFF
--- a/data/102/312/305/102312305.geojson
+++ b/data/102/312/305/102312305.geojson
@@ -975,9 +975,11 @@
     ],
     "wof:breaches":[],
     "wof:concordances":{
+        "iso:code":"UN",
         "tgn:id":7029605,
         "wd:id":"Q1065"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"UN",
     "wof:geomhash":"7ed71bd71aa9b6c897d0bed6f5ee1f31",
     "wof:hierarchy":[
@@ -1004,7 +1006,7 @@
         "spa",
         "mul"
     ],
-    "wof:lastmodified":1694492049,
+    "wof:lastmodified":1695881158,
     "wof:name":"United Nations",
     "wof:parent_id":102191575,
     "wof:placetype":"country",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.